### PR TITLE
MDK-1615: Scenario run always returns errors

### DIFF
--- a/spotcli/configuration/tasks.py
+++ b/spotcli/configuration/tasks.py
@@ -279,5 +279,4 @@ class Scenario:
     def run(self):
         results = []
         for task in self.tasks:
-            results.extend(task.run())
-        return results
+            task.run()


### PR DESCRIPTION
before: 
<img width="401" alt="image" src="https://user-images.githubusercontent.com/18227724/103217427-3a8d0180-4921-11eb-8d69-e87785a69d83.png">

after:
<img width="792" alt="image" src="https://user-images.githubusercontent.com/18227724/103217270-e1bd6900-4920-11eb-82d8-bb57fbd94865.png">

(checked with ` spotcli status ow --show-processes` to see that my change keeps functionality working) 